### PR TITLE
Update example command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ npm install -g circom
 The circuit is compiled with the following command:
 
 ```
-circom mycircuit.circom -o mycircuit.json
+circom mycircuit.circom -c mycircuit.json
 ```
 
 The resulting output ( `mycircuit.json` ) can be used in the [zksnarks JavaScript library](https://github.com/iden3/zksnark).


### PR DESCRIPTION
The circuit is compiled with the following command: Changed ``circom mycircuit.circom -o mycircuit.json`` to ``circom mycircuit.circom -c mycircuit.json`` as old command flag does not work anymore.